### PR TITLE
Upgrade alpine to 3.10

### DIFF
--- a/k8s.yml
+++ b/k8s.yml
@@ -8,7 +8,7 @@ description: Kubernetes related commands and jobs
 executors:
   default:
     docker:
-      - image: alpine:3.9
+      - image: alpine:3.10
   build:
     docker:
       - image: docker:18.09.6


### PR DESCRIPTION
This PR addresses the need to use Python version 3.7+ in the pipeline which does not exist in 3.9 repository. 